### PR TITLE
small update for rf_trn

### DIFF
--- a/R/rf_trn.R
+++ b/R/rf_trn.R
@@ -1,6 +1,6 @@
-#' rf_CV allows assessing the final DEGs through a machine learning step by using Random Forest in a cross validation process.
+#' rf_trn allows assessing the final DEGs through a machine learning step by using Random Forest in a cross validation process.
 #'
-#' rf_CV allows assessing the final DEGs through a machine learning step by using Random Forest in a cross validation process. This function applies a cross validation of n folds with representation of all classes in each fold. The 80\% of the data are used for training and the 20\% for test.
+#' rf_trn allows assessing the final DEGs through a machine learning step by using Random Forest in a cross validation process. This function applies a cross validation of n folds with representation of all classes in each fold. The 80\% of the data are used for training and the 20\% for test.
 #'
 #' @param data The data parameter is an expression matrix or data.frame that contains the genes in the columns and the samples in the rows.
 #' @param labels A vector or factor that contains the labels for each of the samples in the data object.
@@ -56,7 +56,7 @@ rf_trn <- function(data,labels,vars_selected,numFold=10){
     tuning <- tuneRF(data, labels, ntreeTry = tree, doBest = T)
     bestParamsMatrix[i,1] <- tuning$mtry
     bestParamsMatrix[i,2] <- tree
-    bestParamsMatrix[i,3] <- mean(tuning$confusion[,4])
+    bestParamsMatrix[i,3] <- mean(tuning$confusion[, "class.error"])
   
     i = i + 1
     


### PR DESCRIPTION
Calling a variable by his name (and not position) to make the code useful for binary classification, and minor changes in documentation.

PS: This PR does not fix another error found when running the example available of the function:

```
> dir <- system.file("extdata", package="KnowSeq")
> load(paste(dir,"/expressionExample.RData",sep = ""))
> 
> rf_trn(t(DEGsMatrix),labels,rownames(DEGsMatrix),2)
Tuning the optimal mtry and ntrees...
mtry = 14  OOB error = 0% 
Searching left ...
mtry = 7 	OOB error = 0% 
NaN 0 
Error in if (Improve > improve) { : missing value where TRUE/FALSE needed
```

Error seems related to getting OOB = 0% because apparently variables are correlated (https://discuss.analyticsvidhya.com/t/error-in-tunerf/10247/2). I've tried using different `improve` parameter in `randomForest::tuneRF` with no improvements.

With GDC Portal data I don't get neither the error nor OOB = 0%. Maybe it's related with that specific data? If that's the case we can change the example of the function.