### PR TITLE
Data plot heatmap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,6 @@ Encoding: UTF-8
 LazyData: false
 RoxygenNote: 7.1.1
 biocViews: GeneExpression, DifferentialExpression, GeneSetEnrichment, DataImport, Classification, FeatureExtraction, Sequencing, RNASeq, BatchEffect, Normalization, Preprocessing, QualityControl, Genetics, Transcriptomics, Microarray, Alignment, Pathways, SystemsBiology, GO, ImmunoOncology
-Imports: stringr, ggplot2 (>= 3.3.0), jsonlite, rlist, rmarkdown, reshape2, gplots, caret, XML, praznik, R.utils, httr, sva (>= 3.30.1), edgeR (>= 3.24.3), limma (>= 3.38.3), grDevices, graphics, stats, utils, Hmisc (>= 4.4.0)
+Imports: stringr, ggplot2 (>= 3.3.0), jsonlite, rlist, rmarkdown, reshape2, caret, XML, praznik, R.utils, httr, sva (>= 3.30.1), edgeR (>= 3.24.3), limma (>= 3.38.3), grDevices, graphics, stats, utils, Hmisc (>= 4.4.0)
 Suggests: knitr
 git_url: https://github.com/CasedUgr/KnowSeq

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,8 +3,7 @@ import(stringr, XML)
 importFrom(sva, sva, f.pvalue, num.sv, ComBat)
 importFrom(jsonlite, fromJSON)
 importFrom(R.utils, mkdirs, gunzip)
-importFrom(gplots, heatmap.2, redgreen)
-importFrom(ggplot2, ggplot, ggsave, geom_boxplot, facet_wrap, aes, theme_minimal,scale_fill_manual,ggtitle, ylab, xlab, labs, geom_tile, theme, element_text, geom_point, geom_segment, scale_y_discrete, theme_classic, scale_x_discrete, geom_vline, xlim, ylim, annotate)
+importFrom(ggplot2, ggplot, ggsave, geom_boxplot, geom_tile, facet_wrap, aes, theme_minimal, theme_classic, theme, scale_fill_manual, ggtitle, ylab, xlab, labs, coord_flip, geom_tile, element_text, geom_point, geom_segment, scale_y_discrete, scale_x_discrete, geom_vline, xlim, ylim, annotate)
 importFrom(grDevices, colorRampPalette, dev.off, hsv, pdf, png)
 importFrom(graphics, abline, axis, box, boxplot, image, layout, lines, par, text, title, grid, smoothScatter)
 importFrom(stats, model.matrix, p.adjust, setNames, complete.cases, ecdf,dist, ks.test, quantile, IQR)
@@ -24,4 +23,3 @@ export(batchEffectRemoval, calculateGeneExpressionValues, countsToMatrix, dataPl
               downloadPublicSeries, featureSelection, fileMove, gdcClientDownload, geneOntologyEnrichment, getGenesAnnotation,
               hisatAlignment, knn_trn, knn_test, DEGsExtraction, plotConfMatrix, RNAseqQA, rawAlignment, rf_trn, rf_test
               , sraToFastq, svm_trn, svm_test, DEGsEvidences, knowseqReport, DEGsToPathways)
-

--- a/R/dataPlot.R
+++ b/R/dataPlot.R
@@ -130,7 +130,7 @@ dataPlot <- function(data, labels, colours = c("red", "green"), main = "", ylab 
     data2 <- data2[1:heatmapResultsN, ]
     names(data2) <- c("Accuracy", "Sensitivity", "Specificity", "F1-Score")
     data2 <- melt(t(data2))
-
+    
     graph <- ggplot(data2, aes(Var1, Var2, fill = value)) +
       geom_tile(colour = "black") + 
       scale_fill_gradient(low = colours[1], high = colours[2]) +
@@ -216,36 +216,81 @@ dataPlot <- function(data, labels, colours = c("red", "green"), main = "", ylab 
       
     }
     
-    coloursAux <- labels
-    
-    for(i in seq_len(length(levels(as.factor(labels))))){
-      
-      coloursAux <- gsub(levels(as.factor(labels))[i],coloursPalette[i], coloursAux)
-      
+    # Reorder data and labels
+    labels_levels <- levels(as.factor(labels))
+    for(i in 1:length(labels_levels)){
+      if(i == 1) {
+        data_heatmap <- data[, which(labels == labels_levels[1])]
+        labels_heatmap <- labels[which(labels == labels_levels[1])]
+      }
+      else {
+        data_heatmap <- cbind(data_heatmap, data[, which(labels == labels_levels[i])])
+        labels_heatmap <- c(labels_heatmap, labels[which(labels == labels_levels[i])])
+      }
     }
+    
+    data_heatmap <- melt(data_heatmap)
+
+    # Add labels_heatmap to data_heatmap
+    data_heatmap$labels <- NA
+    j <- 1
+    for(i in 1:nrow(data_heatmap)){
+      if(i == 1) data_heatmap$labels[i] <- labels_heatmap[1]
+      else {
+        if(data_heatmap$Var2[i] == data_heatmap$Var2[i - 1]) data_heatmap$labels[i] <- data_heatmap$labels[i - 1]
+        else{
+          j <- j + 1
+          data_heatmap$labels[i] <- labels_heatmap[j]
+        }
+      }
+    }
+    
+    # First graph: labels
+    g1 <- ggplot(data = data_heatmap, aes(x = Var2, y = Var1)) +
+      geom_tile(aes(fill = labels), size = 0, linetype = "blank") +
+      scale_fill_manual(values = coloursPalette) +
+      ggtitle("") + 
+      xlab("") + 
+      ylab("") + 
+      coord_flip() + 
+      theme_minimal() + 
+      theme(axis.text = element_text(color = "black"),
+            axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, size = 10, color = "white"),
+            axis.text.y = element_blank(),
+            plot.title = element_text(hjust = .5),
+            axis.ticks = element_blank(),
+            legend.position="left",
+            legend.margin=margin(t = 0, unit='cm'))
+    
+    # Second graph: data
+    g2 <- ggplot(data = data_heatmap, aes(x = Var2, y = Var1)) +
+      geom_tile(aes(fill = value), size = 0, linetype = "blank") +
+      scale_fill_gradientn(colors = c("red", "black", "green")) +
+      ggtitle(main) + 
+      xlab(xlab) + 
+      ylab(ylab) + 
+      coord_flip() + 
+      theme_minimal() + 
+      theme(axis.text = element_text(color = "black"),
+            axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, size = 10),
+            axis.text.y = element_blank(),
+            plot.title = element_text(hjust = .5))
+    
+    # Join the two graphs
+    grid.arrange(g1, g2, ncol = 2, nrow = 1, widths = c(1, 1.5))
+    
+    cat("Warning! If you can't see the plot of the labels, you should use shorter labels. \n")
     
     if(toPNG){
       cat("Creating PNG...\n")
-      png("heatmap.png",width = 1024, height = 720)
-      heatmap.2(t(data), col=redgreen(75), scale="row", RowSideColors=coloursAux,
-                key=TRUE, symkey=FALSE, density.info="none", trace="none", cexRow=1,
-                cexCol=1, margins=c(6,11),srtCol=45)
-      dev.off()
+      ggsave(filename = "heatmap.png")
     }
     
     if(toPDF){
       cat("Creating PDF...\n")
-      pdf("heatmap.pdf")
-      heatmap.2(t(data), col=redgreen(75), scale="row", RowSideColors=coloursAux,
-                key=TRUE, symkey=FALSE, density.info="none", trace="none", cexRow=1,
-                cexCol=1, margins=c(6,11),srtCol=45)
-      dev.off()
+      ggsave(filename = "heatmap.pdf")
     }
-    
-    heatmap.2(t(data), col=redgreen(75), scale="row", RowSideColors=coloursAux ,
-              key=TRUE, symkey=FALSE, density.info="none", trace="none", cexRow=1,
-              cexCol=1, margins=c(6,11),srtCol=45)
-    
+  
   }else if(mode == "confusionMatrix"){
     
     plotConfMatrix(data)

--- a/R/dataPlot.R
+++ b/R/dataPlot.R
@@ -283,12 +283,16 @@ dataPlot <- function(data, labels, colours = c("red", "green"), main = "", ylab 
     
     if(toPNG){
       cat("Creating PNG...\n")
-      ggsave(filename = "heatmap.png")
+      png("heatmap.png", width = 1024, height = 720)
+      grid.arrange(g1, g2, ncol = 2, nrow = 1, widths = c(1, 1.5))
+      dev.off()
     }
     
     if(toPDF){
       cat("Creating PDF...\n")
-      ggsave(filename = "heatmap.pdf")
+      pdf("heatmap.pdf")
+      grid.arrange(g1, g2, ncol = 2, nrow = 1, widths = c(1, 1.5))
+      dev.off()
     }
   
   }else if(mode == "confusionMatrix"){


### PR DESCRIPTION
This Pull Request removes the `gplots` dependency, using `ggplot2` for the heatmap of `dataPlot`.

**New plot**

```{r}
dataPlot(DEGsMatrix[1:12,], labels, mode = "heatmap")
```

<img width="774" alt="img1" src="https://user-images.githubusercontent.com/18743806/98053242-65cf0500-1e38-11eb-92fc-b8611062b31d.png">

**New plot with custom parameters**

```{r}
dataPlot(DEGsMatrix[1:12,], labels, mode = "heatmap", main = "Título", xlab = "Eje X", ylab = "Eje Y",
         colours = c("blue", "orange", "purple"))
```

<img width="773" alt="img2" src="https://user-images.githubusercontent.com/18743806/98053542-0cb3a100-1e39-11eb-9060-11a713048f30.png">

**Plot of help(dataPlot)**

```{r}
dir <- system.file("extdata", package="KnowSeq")
load(paste(dir,"/expressionExample.RData",sep = ""))

dataPlot(DEGsMatrix[1:12,], labels, mode = "heatmap")
```

<img width="773" alt="img5" src="https://user-images.githubusercontent.com/18743806/98054129-78e2d480-1e3a-11eb-958a-a519e217482d.png">


## Known limitation

When labels are too long, the left graph does not show correctly. This is why a warning (`Warning! If you can't see the plot of the labels, you should use shorter labels.`) is printed whenever a heatmap is plotted.

**Why is this happening?**   
The full width of the plot is divided in 5 parts using `gridExtra::grid.arrange`. The left plot occupies the first 2 parts, and the right plot the other 3. Because the width is limited, the long labels leave no room for the graph. See examples below.

**Plot with long labels**

With long labels, the left plot is reduced.

<img width="774" alt="img3" src="https://user-images.githubusercontent.com/18743806/98053545-10472800-1e39-11eb-8f63-0adb9debfbbc.png">

**Plot with longer labels**

With very long labels, the plot does not show.

<img width="774" alt="img4" src="https://user-images.githubusercontent.com/18743806/98053559-19d09000-1e39-11eb-8ed8-c7f001d60287.png">





