### PR TITLE
fix DEGsToPathways.R

### DIFF
--- a/R/DEGsToPathways.R
+++ b/R/DEGsToPathways.R
@@ -61,8 +61,9 @@ DEGsToPathways <- function(geneList){
       
     }
   }
-  KEGG.data <- KEGG.data[-1,]
+  
   KEGG.data <- as.data.frame(KEGG.data,stringsAsFactors=FALSE)
+  KEGG.data <- KEGG.data[-1,]
   names(KEGG.data) <- c("KEGG_Path","Name","Description","Class","Genes")
   naPos <- which(is.na(KEGG.data) == TRUE)
   


### PR DESCRIPTION
[This is the script I used for debugging](https://gist.github.com/danielredondo/784fb29339aaee077a251e4f7fd4dd33). To summarise: KEGG.data was supposed to be a matrix 1x5 but was actually 5x1.

```
> dim(KEGG.data) # KEGG.data has two rows: one is full of NA, and another one
[1] 2 5
> class(KEGG.data)
[1] "matrix" "array" 
> KEGG.data <- KEGG.data[-1,] # We remove the row of NA values
> dim(KEGG.data) # Now, KEGG.data is not a matrix, but a vector
NULL
> length(KEGG.data)
[1] 5
> KEGG.data <- as.data.frame(KEGG.data,stringsAsFactors=FALSE)
> dim(KEGG.data) # And after turning KEGG.data into a data frame, it now has 5 rows and one column
[1] 5 1
```

DEGsToPathways.R is now tested for genes TOP2A, BMPER and c("BRCA1","MLANA").