### PR TITLE
Fix knn_test

### DIFF
--- a/R/geneOntologyEnrichment.R
+++ b/R/geneOntologyEnrichment.R
@@ -84,6 +84,8 @@ geneOntologyEnrichment <- function(geneList, geneType="ENTREZ_GENE_ID", ontologi
       act.gos[['GO.ID']] <- ontology.term[,1]
       act.gos[['Term']] <- ontology.term[,2] 
 
+      # Remove NAs
+      genes.annotations <- genes.annotations[!is.na(genes.annotations$entrezgene_id),]
       
       # Add column with gene symbols
       gene.names <- act.gos$Genes


### PR DESCRIPTION
`knn_test` returned an error when only using 1 gene.

This is the example of the function `knn_test` adapted to only one gene:
```
> dir <- system.file("extdata", package="KnowSeq")
> load(paste(dir,"/expressionExample.RData",sep = ""))
> 
> trainingMatrix <- t(DEGsMatrix)[c(1:4,6:9),]
> trainingLabels <- labels[c(1:4,6:9)]
> testMatrix <- t(DEGsMatrix)[c(5,10),]
> testLabels <- labels[c(5,10)]
> bestK <- 3 # the one that has been selected
> 
> results_test_knn <- knn_test(trainingMatrix, trainingLabels, testMatrix, testLabels, rownames(DEGsMatrix)[1], bestK)
Error in double(nrow(train)) : invalid 'length' argument
```

And after this fix:
```
> results_test_knn <- knn_test(trainingMatrix, trainingLabels, testMatrix, testLabels, rownames(DEGsMatrix)[1], bestK)
Testing with 1 variables...
Classification done successfully!
```